### PR TITLE
feat(global): implement global exception handler

### DIFF
--- a/src/main/java/fortfrut/exception/ErrorResponse.java
+++ b/src/main/java/fortfrut/exception/ErrorResponse.java
@@ -1,0 +1,19 @@
+package fortfrut.exception;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ErrorResponse {
+
+    private int status;
+    private String message;
+    private LocalDateTime timestamp;
+    private List<String> errors;
+}

--- a/src/main/java/fortfrut/exception/GlobalExceptionHandler.java
+++ b/src/main/java/fortfrut/exception/GlobalExceptionHandler.java
@@ -1,7 +1,51 @@
 package fortfrut.exception;
 
-public class GlobalExceptionHandler extends RuntimeException {
-  public GlobalExceptionHandler(String message) {
-    super(message);
-  }
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.NOT_FOUND.value())
+                .message(ex.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        List<String> errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(field -> field.getField() + ": " + field.getDefaultMessage())
+                .toList();
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message("Validation failed")
+                .timestamp(LocalDateTime.now())
+                .errors(errors)
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
+        ErrorResponse error = ErrorResponse.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .message("Internal server error")
+                .timestamp(LocalDateTime.now())
+                .build();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
 }

--- a/src/main/java/fortfrut/exception/GlobalExceptionHandler.java
+++ b/src/main/java/fortfrut/exception/GlobalExceptionHandler.java
@@ -1,0 +1,7 @@
+package fortfrut.exception;
+
+public class GlobalExceptionHandler extends RuntimeException {
+  public GlobalExceptionHandler(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## O que foi feito
- Criação do ErrorResponse com status, message, timestamp e errors
- Implementação do GlobalExceptionHandler com @RestControllerAdvice

## Exceptions tratadas
- RuntimeException → 404 Not Found
- MethodArgumentNotValidException → 400 Bad Request
- Exception → 500 Internal Server Error